### PR TITLE
convert tensor type to match for torch.matmul

### DIFF
--- a/matmul_utils_4bit.py
+++ b/matmul_utils_4bit.py
@@ -77,6 +77,7 @@ def _matmul4bit_v1_recons(x, qweight, scales, zeros, transpose=False):
         assert qweight.shape[1] == x.shape[-1]
     buffer = get_buffer(qweight.shape, dtype=scales.dtype, device=qweight.device)
     quant_cuda.vecquant4recons_v1(qweight, buffer, scales, zeros)
+    x = x.to(scales.dtype)
     if not transpose:
         output = torch.matmul(x, buffer)
     else:


### PR DESCRIPTION
fixes:

```
  File "/opt/conda/lib/python3.10/site-packages/peft/tuners/lora.py", line 686, in forward
    result = super().forward(x)
  File "/workspace/alpaca_lora_4bit/autograd_4bit.py", line 63, in forward
    out = mm4b.matmul4bit(x, self.qweight, self.scales,
  File "/workspace/alpaca_lora_4bit/matmul_utils_4bit.py", line 109, in matmul4bit
    output = _matmul4bit_v1_recons(x, qweight, scales, zeros)
  File "/workspace/alpaca_lora_4bit/matmul_utils_4bit.py", line 81, in _matmul4bit_v1_recons
    output = torch.matmul(x, buffer)
RuntimeError: expected scalar type Float but found Half
```