### PR TITLE
Fix Dockerfile for No module named 'monkeypatch'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN cd text-generation-webui-tmp && python download-model.py samwit/alpaca7b-lor
 
 COPY *.py .
 COPY text-generation-webui text-generation-webui
-COPY monkeypatch .
+COPY monkeypatch text-generation-webui/monkeypatch
 
 RUN mv -f text-generation-webui-tmp/* text-generation-webui/
 


### PR DESCRIPTION
Traceback (most recent call last):
  File "/alpaca_lora_4bit/text-generation-webui/server.py", line 1, in <module>
    import custom_monkey_patch # apply monkey patch
  File "/alpaca_lora_4bit/text-generation-webui/custom_monkey_patch.py", line 6, in <module>
    from monkeypatch.peft_tuners_lora_monkey_patch import replace_peft_model_with_gptq_lora_model, Linear4bitLt
ModuleNotFoundError: No module named 'monkeypatch'