### PR TITLE
Add Weights & Biases integration

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -131,6 +131,13 @@ if not ft_config.skip:
     if not ft_config.ddp and torch.cuda.device_count() > 1:
         model.is_parallelizable = True
         model.model_parallel = True
+        
+    # Count eval count for wandb
+    eval_count = 10
+    eval_steps = max(
+        ft_config.logging_steps, (len(data.train_data) + len(data.val_data)) // (eval_count*ft_config.mbatch_size)
+    )
+    print(f"Run eval every {eval_steps} steps")
 
     training_arguments = transformers.TrainingArguments(
         per_device_train_batch_size=ft_config.mbatch_size,
@@ -141,9 +148,9 @@ if not ft_config.skip:
         learning_rate=ft_config.lr,
         fp16=True,
         logging_steps=ft_config.logging_steps,
-        evaluation_strategy="no",
+        evaluation_strategy="steps",
         save_strategy="steps",
-        eval_steps=None,
+        eval_steps=eval_steps,
         save_steps=ft_config.save_steps,
         output_dir=ft_config.lora_out_dir,
         save_total_limit=ft_config.save_total_limit,

--- a/finetune.py
+++ b/finetune.py
@@ -42,6 +42,7 @@ import os
 import peft
 import peft.tuners.lora
 
+import wandb
 import torch
 import transformers
 from autograd_4bit import load_llama_model_4bit_low_ram
@@ -170,13 +171,14 @@ if not ft_config.skip:
         transformers.logging.set_verbosity_info()
 
     # Run Trainer
-    if ft_config.resume_checkpoint:
-        print('Resuming from {} ...'.format(ft_config.resume_checkpoint))
-        state_dict_peft = torch.load(os.path.join(ft_config.resume_checkpoint, 'pytorch_model.bin'), map_location='cpu')
-        set_peft_model_state_dict(model, state_dict_peft)
-        trainer.train(ft_config.resume_checkpoint)
-    else:
-        trainer.train()
+    with wandb.init(project="alpaca_lora_4bit") as run:
+        if ft_config.resume_checkpoint:
+            print('Resuming from {} ...'.format(ft_config.resume_checkpoint))
+            state_dict_peft = torch.load(os.path.join(ft_config.resume_checkpoint, 'pytorch_model.bin'), map_location='cpu')
+            set_peft_model_state_dict(model, state_dict_peft)
+            trainer.train(ft_config.resume_checkpoint)
+        else:
+            trainer.train()
 
     # Restore old model state dict
     model.state_dict = old_state_dict

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pyzmq
 git+https://github.com/huggingface/peft.git@70af02a2bca5a63921790036b2c9430edf4037e2
 git+https://github.com/huggingface/transformers.git
 git+https://github.com/sterlind/GPTQ-for-LLaMa.git@lora_4bit
+wandb


### PR DESCRIPTION
This PR adds wandb integration for [alpaca_lora_4bit](https://github.com/johnsmith0031/alpaca_lora_4bit)

wandb is an instrument that integrates in torch to make a good training process visualization:
<img width="1652" alt="image" src="https://github.com/johnsmith0031/alpaca_lora_4bit/assets/25303578/ea24acff-43ca-4612-a262-c03477ba0d93">
<img width="1654" alt="image" src="https://github.com/johnsmith0031/alpaca_lora_4bit/assets/25303578/08e38c68-bdf0-4a18-b18d-b5b03f147565">

There are visualizations generated by wandb. It helps to:
- compare the difference between runs (the most essential for me is eval/loss) so you can easily experiment with training parameters.
- track your current runs when you are "out from keyboard" (e.g. for watching your torch run on smartphone)
- visualize that your current run is bad (e.g. you tried to reformulate the instruction and it showed worse result) and have a visualized reason to kill this run.
- share your training results with community. It can be good for sharing lora runs. Reports are private by default.
- hardware troubleshooting: wandb visualizes data about your hardware status (power usage, allocated memory, utilization, etc):
<img width="1660" alt="image" src="https://github.com/johnsmith0031/alpaca_lora_4bit/assets/25303578/5e37232d-ae47-4529-ba5f-4c3aae208918">


Also I found that your code does not use eval dataset at all despite it prepares it: https://github.com/johnsmith0031/alpaca_lora_4bit/blob/main/train_data.py#L166
So every time 20% of dataset was just unused.