### PR TITLE
Fixed triton `do_bench` non-None quantiles/percentiles default (issue 101)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pyzmq
 wandb
 peft @ git+https://github.com/huggingface/peft.git@70af02a2bca5a63921790036b2c9430edf4037e2
 transformers @ git+https://github.com/huggingface/transformers.git
+packaging

--- a/src/alpaca_lora_4bit/custom_autotune.py
+++ b/src/alpaca_lora_4bit/custom_autotune.py
@@ -6,6 +6,7 @@ Mostly the same as the autotuner in Triton, but with a few changes like using 40
 import builtins
 import math
 import time
+from packaging import version
 from typing import Dict
 
 import triton
@@ -68,7 +69,11 @@ class Autotuner(triton.KernelInterface):
 		try:
 			# In testings using only 40 reps seems to be close enough and it appears to be what PyTorch uses
 			# PyTorch also sets fast_flush to True, but I didn't see any speedup so I'll leave the default
-			return triton.testing.do_bench(kernel_call, rep=40)
+			if version.parse(triton.__version__) > version.parse("2.0.0.post1"):
+				bench_kwargs = {"quantiles": None}
+			else:
+				bench_kwargs = {"percentiles": None}
+			return triton.testing.do_bench(kernel_call, rep=40, **bench_kwargs)
 		except triton.compiler.OutOfResources:
 			return float('inf')
 


### PR DESCRIPTION
Hi. I made a bugfix for the issue I mentioned here: https://github.com/johnsmith0031/alpaca_lora_4bit/issues/101

TL;DR; despite the latest github triton `do_bench` function code have quantiles/percentiles setted to None by default - the versions which is currently available through pypi (up to `2.0.0.post1`) have `percentiles=(0.5, 0.2, 0.8)` which causes the following code to break:

```
	def _bench(self, *args, config, **meta):
	        ...
		try:
			# In testings using only 40 reps seems to be close enough and it appears to be what PyTorch uses
			# PyTorch also sets fast_flush to True, but I didn't see any speedup so I'll leave the default
			return triton.testing.do_bench(kernel_call, rep=40)
		except triton.compiler.OutOfResources:
			return float('inf')
...
				timings = {config: self._bench(*args, config=config, **kwargs)
							for config in pruned_configs}
				bench_end = time.time()
				self.bench_time = bench_end - bench_start
				self.cache[key] = builtins.min(timings, key=timings.get)

```
because instead of float numbers the `timings` dict is filled with tuples (for 0.5/0.2/0.8 percentile).