### PR TITLE
Remove import of custom_autotune (it's triton-dependent, triton depen…

### DIFF
--- a/src/alpaca_lora_4bit/__init__.py
+++ b/src/alpaca_lora_4bit/__init__.py
@@ -2,7 +2,6 @@ from . import monkeypatch
 from . import amp_wrapper
 from . import arg_parser
 from . import autograd_4bit
-from . import custom_autotune
 from . import Finetune4bConfig
 from . import gradient_checkpointing
 from . import models
@@ -10,3 +9,4 @@ from . import train_data
 # We don't import these automatically as it is dependent on whether we need cuda or triton
 # from . import matmul_utils_4bit
 # from . import triton_utils
+# from . import custom_autotune


### PR DESCRIPTION
Since `triton` package dependency is optional:

https://github.com/johnsmith0031/alpaca_lora_4bit/blob/winglian-setup_pip/setup.py#L25
```
    extras_require={
        'triton': 'triton',
    },
```

I think we should't have the following import:

https://github.com/alex4321/alpaca_lora_4bit/blob/winglian-setup_pip/src/alpaca_lora_4bit/__init__.py#L5
```
from . import custom_autotune
```

Because it's a triton-depending module:
https://github.com/johnsmith0031/alpaca_lora_4bit/blob/winglian-setup_pip/src/alpaca_lora_4bit/custom_autotune.py#L12
```

import triton


class Autotuner(triton.KernelInterface):
```

So I moved import to implementation-depending comments section