### PR TITLE
Use PyPI versions of dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ einops
 colorama
 pyzmq
 wandb
-peft @ git+https://github.com/huggingface/peft.git@70af02a2bca5a63921790036b2c9430edf4037e2
-transformers @ git+https://github.com/huggingface/transformers.git
+peft
+transformers
 packaging


### PR DESCRIPTION
Since the initial dependency on github's transformers main-branch version and specific commit inside peft:
```
git+https://github.com/huggingface/peft.git@70af02a2bca5a63921790036b2c9430edf4037e2
git+https://github.com/huggingface/transformers.git
```
were set up a long ago - I tried to check if pypi stable versions works fine now.

It seems so in cases I tried, so maybe we do not need do depend on old specific peft commit and non-stable transformers version anymore?

p.s. I guess I would also make some autotests later, to check such an ideas better than just "well, I runned some of my inference and finetuning scripts depending on this stuff". Anyway, that's offtopic regards this specific PR.