### PR TITLE
Tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ einops
 colorama
 pyzmq
 wandb
-peft @ git+https://github.com/huggingface/peft.git@70af02a2bca5a63921790036b2c9430edf4037e2
-transformers @ git+https://github.com/huggingface/transformers.git
+peft
+transformers
 packaging

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,9 @@ setup(
     install_requires=install_requires,
     extras_require={
         'triton': 'triton',
+        'dev': [
+            'pytest',
+        ],
     },
     ext_modules=[quant_cuda_module],
     cmdclass={'build_ext': BuildExtension},

--- a/tests/test_cuda_finetune.py
+++ b/tests/test_cuda_finetune.py
@@ -1,0 +1,103 @@
+import numpy as np
+from utils import get_test_alpaca_no_act_order_model, set_seeds
+import pytest
+import multiprocessing as mp
+
+
+def inner_cuda_finetune(flash_attn, mm4b_faster_mode):
+    """
+    Since we do monkey patching - we can not run, for instance:
+    1. test with flash-attention patch
+    2. than another one without it
+    3. than again with it
+    So I make this function work inside separated process instead
+    """
+    import torch
+    import torch.nn.functional as F
+    from alpaca_lora_4bit import autograd_4bit
+    from alpaca_lora_4bit.amp_wrapper import AMPWrapper
+    import alpaca_lora_4bit.matmul_utils_4bit as mm4b
+    from alpaca_lora_4bit.monkeypatch.llama_flash_attn_monkey_patch import replace_llama_attn_with_flash_attn
+    from alpaca_lora_4bit.gradient_checkpointing import apply_gradient_checkpointing
+    from alpaca_lora_4bit.monkeypatch.peft_tuners_lora_monkey_patch import replace_peft_model_with_int4_lora_model
+    from torch.optim import Adam
+    
+    replace_peft_model_with_int4_lora_model()
+
+    from peft import LoraConfig, get_peft_model
+
+    
+    if flash_attn:
+        replace_llama_attn_with_flash_attn()
+
+    autograd_4bit.switch_backend_to("cuda")
+    mm4b.act_order = False
+    mm4b.faster_mode = mm4b_faster_mode
+
+    config_path, weights_path = get_test_alpaca_no_act_order_model()
+    model, tokenizer = autograd_4bit.load_llama_model_4bit_low_ram(
+        config_path=config_path,
+        model_path=weights_path,
+        groupsize=128,
+        is_v1_model=False,
+        bits=4,
+    )
+    autograd_4bit.model_to_half(model)
+    AMPWrapper(model).apply_forward()
+
+    prompt = '''I think the meaning of life is to find happiness, and that's something you have to work for and fight for every day.'''
+    input_ids = tokenizer(prompt, return_tensors="pt", add_special_tokens=False)["input_ids"]
+    batch_input = {
+        "input_ids": input_ids[:, :-1].to(model.device),
+        "labels": input_ids[:, 1:].to(model.device),
+    }
+    
+    model.eval()
+    with torch.no_grad():
+        loss_original = model(**batch_input).loss.item()
+
+    set_seeds(42)
+    lora_config = LoraConfig(
+        r=8,
+        lora_alpha=16,
+        target_modules=["q_proj", "v_proj"],
+        lora_dropout=0.0,
+        bias="none",
+        task_type="CAUSAL_LM",
+    )
+    lora_model = get_peft_model(model, lora_config)
+    for _, m in lora_model.named_modules():
+        if 'Autograd4bitQuantLinear' in str(type(m)) or 'Linear4bitLt' in str(type(m)):
+            if hasattr(m, "is_v1_model") and m.is_v1_model:
+                m.zeros = m.zeros.half()
+            m.scales = m.scales.half()
+    apply_gradient_checkpointing(lora_model)
+
+    optimizer = Adam(lora_model.parameters(), lr=1e-4)
+    for _ in range(25):
+        optimizer.zero_grad()
+        loss = lora_model(**batch_input).loss
+        loss.backward()
+        optimizer.step()
+    
+    model.eval()
+    with torch.no_grad():
+        loss_tuned = model(**batch_input).loss.item()
+
+    assert loss_original >= 10.0 and loss_tuned <= 3.0
+
+
+@pytest.mark.parametrize("flash_attn, mm4b_faster_mode, fails", [
+    (False, "disable", False),
+    (False, "old_faster", False),
+    (False, "faster", False),
+])
+def test_cuda_forwardpass_no_act_order(flash_attn, mm4b_faster_mode, fails):
+    # I don't do FlashAttention tests here right now because my GPU can't do backward pass with currect flash-attn implementation on LLAMA-like models
+    process = mp.Process(target=inner_cuda_finetune, args=(flash_attn, mm4b_faster_mode))
+    process.start()
+    process.join()
+    if fails:
+        assert process.exitcode != 0
+    else:
+        assert process.exitcode == 0

--- a/tests/test_cuda_generation.py
+++ b/tests/test_cuda_generation.py
@@ -1,42 +1,84 @@
-import torch
-from alpaca_lora_4bit.autograd_4bit import load_llama_model_4bit_low_ram, model_to_half
-from alpaca_lora_4bit.amp_wrapper import AMPWrapper
-import alpaca_lora_4bit.matmul_utils_4bit as mm4b
-from utils import get_test_alpaca_no_act_order_model, set_seeds
-import random
+
 import numpy as np
+from utils import get_test_alpaca_no_act_order_model, set_seeds
+import pytest
+import multiprocessing as mp
 
 
-def test_cuda_generation_no_act_order():
+def inner_cuda_generation_no_act_order(flash_attn, mm4b_faster_mode):
+    """
+    Since we do monkey patching - we can not run, for instance:
+    1. test with flash-attention patch
+    2. than another one without it
+    3. than again with it
+    So I make this function work inside separated process instead
+    """
+    import torch
+    import torch.nn.functional as F
+    from alpaca_lora_4bit import autograd_4bit
+    from alpaca_lora_4bit.amp_wrapper import AMPWrapper
+    import alpaca_lora_4bit.matmul_utils_4bit as mm4b
+    from alpaca_lora_4bit.monkeypatch.llama_flash_attn_monkey_patch import replace_llama_attn_with_flash_attn
+    
+    if flash_attn:
+        replace_llama_attn_with_flash_attn()
+    autograd_4bit.backend = "cuda"
+    mm4b.act_order = False
+    mm4b.faster_mode = mm4b_faster_mode
     config_path, weights_path = get_test_alpaca_no_act_order_model()
-    model, tokenizer = load_llama_model_4bit_low_ram(
+    model, tokenizer = autograd_4bit.load_llama_model_4bit_low_ram(
         config_path=config_path,
         model_path=weights_path,
         groupsize=128,
         is_v1_model=False,
+        bits=4,
     )
-    model_to_half(model)
+    autograd_4bit.model_to_half(model)
     AMPWrapper(model).apply_generate()
-
-    prompt = '''I think the meaning of life is'''
-    batch = tokenizer(prompt, return_tensors="pt", add_special_tokens=False)
-    batch = {k: v.cuda() for k, v in batch.items()}
-
-    mm4b.act_order = False
-    mm4b.faster_mode = "disabled"
-
+    prompt = '''I think the meaning of life is to find happiness, and that's something you have to work for and fight for every day.'''
+    batch_input = tokenizer(prompt, return_tensors="pt", add_special_tokens=False)
+    batch_input = {
+        k: v.to(model.device)
+        for k, v in batch_input.items()
+    }
     set_seeds(42)
     with torch.no_grad():
-        generated = model.generate(inputs=batch["input_ids"],
-                                do_sample=True, use_cache=True,
-                                repetition_penalty=1.1,
-                                max_new_tokens=20,
-                                temperature=0.9,
-                                top_p=0.95,
-                                top_k=40,
-                                return_dict_in_generate=True,
-                                output_attentions=False,
-                                output_hidden_states=False,
-                                output_scores=False)
-    result_text = tokenizer.decode(generated['sequences'].cpu().tolist()[0])
-    raise ValueError(result_text)
+        # Since output_scores gives me -Inf probabilities while text is not gibberish - sounds like some bug in generate method
+        # So let's just make 1 more forward pass
+        model.eval()
+        scores = F.softmax(model(**batch_input).logits, dim=-1)
+    scores_np = scores.detach().cpu().numpy()
+    
+    top_tokens_canonical = np.array([21130,   357,  1153,   287,   266,   322,
+                                       289,   333, 12591, 31844,   291,   342,
+                                     31876, 31829,   674,   342,   473,   289,
+                                       623,   329,   291,   342,   329,   291,
+                                       1124, 31843,   571])
+    top_tokens_scores_canonical = np.array([3.765e-04, 1.888e-01, 3.259e-02,
+                                            8.105e-01, 3.274e-01, 8.257e-01,
+                                            6.084e-01, 2.734e-01, 6.250e-01,
+                                            4.512e-01, 5.156e-01, 2.930e-01,
+                                            2.186e-01, 1.000e+00, 6.196e-01,
+                                            8.799e-01, 6.099e-01, 9.922e-01,
+                                            8.315e-01, 5.923e-01, 2.910e-01,
+                                            2.510e-01, 9.980e-01, 2.646e-01,
+                                            7.036e-01, 5.073e-01, 1.936e-01])
+    top_tokens = scores_np[0].argmax(axis=-1)
+    top_tokens_scores = scores_np[0].max(axis=-1)
+    assert all(top_tokens == top_tokens_canonical)
+    assert all(np.abs(top_tokens_scores.astype(np.float32) - top_tokens_scores_canonical.astype(np.float32)) < 1e-3)
+
+
+@pytest.mark.parametrize("flash_attn, mm4b_faster_mode", [
+    (True, "disable"),
+    (True, "old_faster"),
+    (True, "faster"),
+    (False, "disable"),
+    (False, "old_faster"),
+    (False, "faster"),
+])
+def test_cuda_generation_no_act_order(flash_attn, mm4b_faster_mode):
+    process = mp.Process(target=inner_cuda_generation_no_act_order, args=(flash_attn, mm4b_faster_mode))
+    process.start()
+    process.join()
+    assert process.exitcode == 0

--- a/tests/test_cuda_generation.py
+++ b/tests/test_cuda_generation.py
@@ -1,0 +1,42 @@
+import torch
+from alpaca_lora_4bit.autograd_4bit import load_llama_model_4bit_low_ram, model_to_half
+from alpaca_lora_4bit.amp_wrapper import AMPWrapper
+import alpaca_lora_4bit.matmul_utils_4bit as mm4b
+from utils import get_test_alpaca_no_act_order_model, set_seeds
+import random
+import numpy as np
+
+
+def test_cuda_generation_no_act_order():
+    config_path, weights_path = get_test_alpaca_no_act_order_model()
+    model, tokenizer = load_llama_model_4bit_low_ram(
+        config_path=config_path,
+        model_path=weights_path,
+        groupsize=128,
+        is_v1_model=False,
+    )
+    model_to_half(model)
+    AMPWrapper(model).apply_generate()
+
+    prompt = '''I think the meaning of life is'''
+    batch = tokenizer(prompt, return_tensors="pt", add_special_tokens=False)
+    batch = {k: v.cuda() for k, v in batch.items()}
+
+    mm4b.act_order = False
+    mm4b.faster_mode = "disabled"
+
+    set_seeds(42)
+    with torch.no_grad():
+        generated = model.generate(inputs=batch["input_ids"],
+                                do_sample=True, use_cache=True,
+                                repetition_penalty=1.1,
+                                max_new_tokens=20,
+                                temperature=0.9,
+                                top_p=0.95,
+                                top_k=40,
+                                return_dict_in_generate=True,
+                                output_attentions=False,
+                                output_hidden_states=False,
+                                output_scores=False)
+    result_text = tokenizer.decode(generated['sequences'].cpu().tolist()[0])
+    raise ValueError(result_text)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,26 @@
+import torch
+import random
+import numpy as np
+from huggingface_hub import hf_hub_download
+
+
+def get_test_alpaca_no_act_order_model():
+    repository = "TheBloke/orca_mini_7B-GPTQ"
+    files = [".gitattributes", "README.md", "config.json",
+             "generation_config.json", "orca-mini-7b-GPTQ-4bit-128g.no-act.order.safetensors", 
+             "quantize_config.json", "special_tokens_map.json", "tokenizer.json", "tokenizer.model",
+             "tokenizer_config.json"]
+    local_paths = {}
+    for file in files:
+        local_paths[file] = hf_hub_download(
+            repo_id=repository,
+            filename=file,
+        )
+    raise ValueError(local_paths)
+    return local_paths["config.json"], local_paths["orca-mini-7b-GPTQ-4bit-128g.no-act.order.safetensors"]
+
+
+def set_seeds(seed):
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,7 @@ import torch
 import random
 import numpy as np
 from huggingface_hub import hf_hub_download
+import os
 
 
 def get_test_alpaca_no_act_order_model():
@@ -16,8 +17,7 @@ def get_test_alpaca_no_act_order_model():
             repo_id=repository,
             filename=file,
         )
-    raise ValueError(local_paths)
-    return local_paths["config.json"], local_paths["orca-mini-7b-GPTQ-4bit-128g.no-act.order.safetensors"]
+    return os.path.dirname(local_paths["config.json"]), local_paths["orca-mini-7b-GPTQ-4bit-128g.no-act.order.safetensors"]
 
 
 def set_seeds(seed):


### PR DESCRIPTION
Since I am probably going to use the library now more and send some more patches in case I will find some real/potential problems (like #133 ) I think it may be usefull to add some autotests to the library.

So far it covers the following cases:

- CUDA kernel
    - forward pass.
      Basically this test see the model next-token-predictions on some phrase:
      - check the most probable next token for every current token is the same as some canonical sequence
      - check if most probable next token scores are similar to some canonical range
      - so it checks if model output in all states is the same as once-recorded standard attention + disabled "faster" mode
       - Attention types:
           - (covered) Standard one
           - (covered) Flash attention
           - (not-covered) XFormers
       - Act/no act order models:
           - (covered) act order models
           - (not covered) no-act order models
       - "Faster" matmul4bit modes
           - (covered) disable
           - (covered) old_faster
           - (covered) faster
  - finetuning.
    Basically, here I just check if I can succesfully overfit LoRA model to remember some phrase *much* better than the original LLaMA model
    - Attention types
        - (covered) Standard
        - (not covered) Flash attention (since flash-attn can not compute backward pass for such a models using customer-grade GPUs like my 2080Ti - I can not test if the test will work now)
        - (not covered) XFormers
       - Act/no act order models:
           - (covered) act order models
           - (not covered) no-act order models
       - "Faster" matmul4bit modes
           - (covered) disable
           - (covered) old_faster
           - (covered) faster
- (not covered) Triton kernel. Since I am using Windows system now I can't check if triton kernels will give the same result as CUDA ones

So what drawbacks may be improved in the future patches (but probably it may be useful in the current state):
- Triton kernel tests, I will probably do it using WSL a few days later
- All attention types
- It depends on the fact https://huggingface.co/TheBloke/orca_mini_7B-GPTQ/tree/main exists on huggingface hub
- Act-order model tests

So, now to run these tests you need to do something like
```bash
python -m pip install . # To rebuild native stuff and generally reinstall the package
python -m pytest # To run tests
```
not sure what is the best way to make pytest run installation before tests (or is it good idea at all)
